### PR TITLE
Improve escapes handling

### DIFF
--- a/test-clear-down.js
+++ b/test-clear-down.js
@@ -10,18 +10,25 @@ function delay(ms) {
   });
 }
 
+async function goUp() {
+  const CURSOR_UP = "\x1B[A";
+  const split = 2;
+  process.stdout.write(CURSOR_UP.slice(0, split));
+  await delay(1);
+  process.stdout.write(CURSOR_UP.slice(split));
+}
+
 async function run() {
   const CLEAR = "\x1B[2J\x1B[3J\x1B[H";
   const CLEAR_DOWN = "\x1B[0J";
   const CLEAR_LINE = "\x1B[2K";
-  const CURSOR_UP = "\x1B[A";
 
   process.stdout.write("Apple: in progress\n");
   await delay(100);
   process.stdout.write("Banana: in progress\n");
   await delay(1000);
-  process.stdout.write(CURSOR_UP);
-  process.stdout.write(CURSOR_UP);
+  await goUp();
+  await goUp();
   process.stdout.write(`${CLEAR_LINE}Apple: done\n`);
   await delay(1000);
   process.stdout.write(`${CLEAR_LINE}Banana: done\n`);

--- a/test-clear-down.js
+++ b/test-clear-down.js
@@ -25,7 +25,7 @@ async function run() {
   process.stdout.write(`${CLEAR_LINE}Apple: done\n`);
   await delay(1000);
   process.stdout.write(`${CLEAR_LINE}Banana: done\n`);
-  process.stdout.write(CLEAR_DOWN);
+  process.stdout.write(`${CLEAR_DOWN}Success!`);
 
   await delay(2000);
   process.stdout.write(CLEAR);

--- a/test-clear.js
+++ b/test-clear.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const CURSOR_DOWN = "\x1B[B";
-
 /**
  * @template T
  * @param {Array<T>} items
@@ -38,8 +36,10 @@ const variants = [
 
 const index = Number(process.argv[2]) || 0;
 
-process.stdout.write(CURSOR_DOWN);
+console.log("Number of variants:", variants.length);
+console.log("Chosen variant (CLI arg 1):", index);
 console.log("Not a simple log");
+process.stdout.write("\x1B[2A");
 
 setTimeout(() => {
   const f = variants[index];

--- a/test/run-pty.test.js
+++ b/test/run-pty.test.js
@@ -83,6 +83,8 @@ function fakeCommand(item, index = 0) {
     statusFromRules: item.statusFromRules,
     defaultStatus: undefined,
     statusRules: [],
+    windowsConptyCursorMoveWorkaround: false,
+    unfinishedEscapeBuffer: "",
     onData: () => notCalled("onData"),
     onRequest: () => notCalled("onRequest"),
     onExit: () => notCalled("onExit"),
@@ -90,7 +92,6 @@ function fakeCommand(item, index = 0) {
     start: () => notCalled("start"),
     kill: () => notCalled("kill"),
     updateStatusFromRules: () => notCalled("updateStatusFromRules"),
-    windowsConptyCursorMoveWorkaround: false,
   };
 }
 


### PR DESCRIPTION
Followup on #29. That PR made sure we don’t break how the actual terminal interprets escape codes, but didn’t fix how _we_ interpret escape codes. This PR buffers unfinished escape codes, so we can pretend that they always come in full in the rest of the code (and use regex to find full escape codes of choice).

It also improves so clear escapes affect the saved history and the “simple log” detection even if they aren’t at the end of a printed chunk.

Finally, printing a newline and then going up one line is still a “simple log” – we always print the keyboard shortcuts one line down, and there is nothing downwards to overwrite.