### PR TITLE
Optimize dashboard rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ GPU rendering seems to be enabled by default, as long as your computer is connec
 
 You can enable GPU rendering always by toggling “Preferences > General > Magic > GPU Rendering + Advanced GPU Settings… > Disable GPU rendering when disconnected from power.”
 
-There might still be occasional flicker. Hopefully the iTerm2 developers will improve this some time. It does not happen in the standard Terminal app.
+run-pty tries to avoid clearing the screen and only redraw lines that have changed, but there might still be occasional flicker. Hopefully the iTerm2 developers will improve this some time. It does not happen in the standard Terminal app.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "4.8.3"
   },
   "scripts": {
-    "start": "node run-pty.js % cat % false % echo hello world % ping localhost % node get-cursor-position.js % node test-keys.js % node signals.js % node slow-kill.js % node slow-kill.js 2000 \"Shutting down…\" % make watch % make signals % node test-clear-down.js % node colored-log.js % node test-exit-in-middle.js % node test-split-color-codes.js",
+    "start": "node run-pty.js % cat % false % echo hello 🇬🇧 🙈 world % echo hello wide 古古古古古古古古古古古 % ping localhost % node get-cursor-position.js % node test-keys.js % node signals.js % node slow-kill.js % node slow-kill.js 2000 \"Shutting down…\" % make watch % make signals % node test-clear-down.js % node colored-log.js % node test-exit-in-middle.js % node test-split-color-codes.js",
     "example": "node run-pty.js example.json",
     "auto-exit": "node run-pty.js --auto-exit=2 % sleep 3 % sleep 1 % sleep 2 % sleep 1 % sleep 1 && echo success",
     "test": "node run-pty.js --auto-exit % prettier --check . % eslint . --report-unused-disable-directives % tsc % jest",

--- a/run-pty.js
+++ b/run-pty.js
@@ -1575,6 +1575,8 @@ const runInteractively = (commandDescriptions, autoExit) => {
     const previousRender =
       current.tag === "Dashboard" &&
       current.previousRender.length <= process.stdout.rows &&
+      Math.max(...current.previousRender.map((line) => line.length)) <=
+        process.stdout.columns &&
       !forceClearScrollback
         ? current.previousRender
         : [];

--- a/run-pty.js
+++ b/run-pty.js
@@ -18,7 +18,7 @@ const Decode = require("tiny-decoders");
  *
  * @typedef {
     | { tag: "Command", index: number }
-    | { tag: "Dashboard" }
+    | { tag: "Dashboard", previousRender: Array<string> }
    } Current
  */
 
@@ -182,6 +182,13 @@ const cursorDown = (n) => `\x1B[${n}B`;
  * @returns {string}
  */
 const cursorHorizontalAbsolute = (n) => `\x1B[${n}G`;
+
+/**
+ * @param {number} y
+ * @param {number} x
+ * @returns {string}
+ */
+const cursorAbsolute = (y, x) => `\x1B[${y};${x}H`;
 
 /**
  * @param {string} string
@@ -1431,7 +1438,7 @@ const getLastLine = (string) => {
  */
 const runInteractively = (commandDescriptions, autoExit) => {
   /** @type {Current} */
-  let current = { tag: "Dashboard" };
+  let current = { tag: "Dashboard", previousRender: [] };
   let attemptedKillAll = false;
   /** @type {Selection} */
   let selection = { tag: "Invisible", index: 0 };
@@ -1561,24 +1568,50 @@ const runInteractively = (commandDescriptions, autoExit) => {
   };
 
   /**
+   * @param {{ forceClearScrollback?: boolean }} options
    * @returns {void}
    */
-  const switchToDashboard = () => {
-    current = { tag: "Dashboard" };
+  const switchToDashboard = ({ forceClearScrollback = false } = {}) => {
+    const previousRender =
+      current.tag === "Dashboard" &&
+      current.previousRender.length <= process.stdout.rows &&
+      !forceClearScrollback
+        ? current.previousRender
+        : [];
+
+    const currentRender = drawDashboard({
+      commands,
+      width: process.stdout.columns,
+      attemptedKillAll,
+      autoExit,
+      selection,
+    })
+      .split("\n")
+      .slice(0, process.stdout.rows);
+
+    const clear = previousRender.length === 0 ? CLEAR : "";
+    const numLinesToClear = previousRender.length - currentRender.length;
+
+    current = { tag: "Dashboard", previousRender: currentRender };
     process.stdout.write(
       HIDE_CURSOR +
         DISABLE_ALTERNATE_SCREEN +
         DISABLE_APPLICATION_CURSOR_KEYS +
         ENABLE_MOUSE +
         RESET_COLOR +
-        CLEAR +
-        drawDashboard({
-          commands,
-          width: process.stdout.columns,
-          attemptedKillAll,
-          autoExit,
-          selection,
-        })
+        clear +
+        currentRender
+          .map((line, index) =>
+            line === previousRender[index]
+              ? ""
+              : cursorAbsolute(index + 1, 1) + CLEAR_RIGHT + line
+          )
+          .join("") +
+        Array.from(
+          { length: numLinesToClear },
+          (_, index) =>
+            cursorAbsolute(currentRender.length + index + 1, 1) + CLEAR_RIGHT
+        ).join("")
     );
   };
 
@@ -1626,7 +1659,7 @@ const runInteractively = (commandDescriptions, autoExit) => {
       (command) => "terminal" in command.status
     );
     if (notExited.length === 0) {
-      switchToDashboard();
+      switchToDashboard({ forceClearScrollback: true });
       process.exit(autoExit.tag === "AutoExit" ? 1 : 0);
     } else {
       for (const command of notExited) {
@@ -1753,7 +1786,7 @@ const runInteractively = (commandDescriptions, autoExit) => {
         onExit: () => {
           // Exit the whole program if all commands have exited.
           if (isDone({ commands, attemptedKillAll, autoExit })) {
-            switchToDashboard();
+            switchToDashboard({ forceClearScrollback: true });
             process.exit(
               autoExit.tag === "AutoExit" && attemptedKillAll ? 1 : 0
             );


### PR DESCRIPTION
- Avoid clearing the screen, which can cause flicker.
- Only redraw lines that have changed.