### PR TITLE
Add select by indicator feature

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     "no-control-regex": "off",
     "no-fallthrough": "off",
     "no-shadow": "error",
+    "no-unused-expressions": "error",
     "object-shorthand": "error",
     "one-var": ["error", "never"],
     "prefer-arrow-callback": "error",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ npm start
 ➡️ <kbd>1</kbd> ️️➡️
 
 ```
-🟢  npm run frontend
+🟢 npm run frontend
 
 > frontend
 > vite --no-clearScreen
@@ -63,7 +63,7 @@ $ npm start
 ➡️ <kbd>ctrl+c</kbd> ➡️
 
 ```
-🟢  npm run frontend
+🟢 npm run frontend
 
 > frontend
 > vite --no-clearScreen
@@ -75,7 +75,7 @@ $ npm start
   ➜  Network: use --host to expose
 ^C
 
-⚪  npm run frontend
+⚪ npm run frontend
 exit 0
 
 [enter]  restart

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ $ npm start
 
 [1-2]    focus command (or click)
 [ctrl+c] kill all
-[↑/↓]    move selection
-[tab]    select by indicator
+[↑↓←→]   move selection
 ```
 
 ➡️ <kbd>1</kbd> ️️➡️
@@ -92,8 +91,7 @@ exit 0
 
 [1-2]    focus command (or click)
 [ctrl+c] kill all
-[↑/↓]    move selection
-[tab]    select by indicator
+[↑↓←→]   move selection
 [enter]  restart exited
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,23 +40,24 @@ $ npm start
 [1-2]    focus command (or click)
 [ctrl+c] kill all
 [↑/↓]    move selection
+[tab]    select by indicator
 ```
 
 ➡️ <kbd>1</kbd> ️️➡️
 
 ```
-🟢 npm run frontend
+🟢  npm run frontend
 
 > frontend
 > vite --no-clearScreen
 
 
-  VITE v3.0.9  ready in 137 ms
+  VITE v3.2.1  ready in 91 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
 ▊
-[ctrl+c] kill (pid 63096)
+[ctrl+c] kill (pid 36842)
 [ctrl+z] dashboard
 ```
 
@@ -69,13 +70,10 @@ $ npm start
 > vite --no-clearScreen
 
 
-  vite v2.8.4 dev server running at:
+  VITE v3.2.1  ready in 91 ms
 
-  > Local: http://localhost:3000/
-  > Network: use `--host` to expose
-
-  ready in 136ms.
-
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
 ^C
 
 ⚪  npm run frontend
@@ -95,6 +93,7 @@ exit 0
 [1-2]    focus command (or click)
 [ctrl+c] kill all
 [↑/↓]    move selection
+[tab]    select by indicator
 [enter]  restart exited
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The JSON format lets you specify additional things apart from the command itself
 
 - defaultStatus: This lets you replace 🟢 with a custom status indicator at startup (before your command has written anything). The value works like for `status`.
 
-- killAllSequence: When you use “kill all” run-pty sends <kbd>ctrl+c</kbd> to all commands. However, not all commands exit when you do that. In such cases, you can use `killAllSequence` to specify what sequence of characters to send to the command to make it exit.
+- killAllSequence: When you use “kill all” (or “restart selected”) run-pty sends <kbd>ctrl+c</kbd> to all commands. However, not all commands exit when you do that. In such cases, you can use `killAllSequence` to specify what sequence of characters to send to the command to make it exit.
 
 ## --auto-exit
 

--- a/run-pty.js
+++ b/run-pty.js
@@ -379,25 +379,15 @@ const drawDashboardCommandLines = (
   const selectedIndicator =
     selection.tag === "ByIndicator" ? selection.indicator : undefined;
 
-  /**
-   * @param {string} string
-   * @param {boolean} isSelected
-   * @param {number} pad
-   * @returns {string}
-   */
-  const highlightWithSeparator = (string, isSelected, pad) =>
-    isSelected
-      ? NO_COLOR
-        ? `${separator.slice(0, -1)}→${string}`
-        : `${separator}${invert(string + " ".repeat(pad))}`
-      : `${separator}${string}`;
-
   return lines.map(({ label, icon, status, title }, index) => {
-    const finalIcon = highlightWithSeparator(
-      icon,
-      icon === selectedIndicator,
-      2, // Make sure that two terminal slots get inverted, no matter the width of the icon.
-    );
+    const finalIcon =
+      icon === selectedIndicator
+        ? NO_COLOR
+          ? `${separator.slice(0, -1)}→${icon}`
+          : // Add two spaces at the end to make sure that two terminal slots get
+            // inverted, no matter the width of the icon.
+            `${separator.slice(0, -1)}${invert(` ${icon}  `)}`
+        : `${separator}${icon}`;
     const start = truncate(`${label}${finalIcon}`, width);
     const startLength =
       removeGraphicRenditions(label).length + separator.length + ICON_WIDTH;
@@ -410,12 +400,17 @@ const drawDashboardCommandLines = (
       startLength +
       separator.length +
       removeGraphicRenditions(truncatedEnd).length;
-    const finalEnd = highlightWithSeparator(
-      truncatedEnd,
+    const highlightedSeparator =
+      icon === selectedIndicator && !NO_COLOR
+        ? invert(" ") + separator.slice(1)
+        : separator;
+    const finalEnd =
       (selection.tag === "Mousedown" || selection.tag === "Keyboard") &&
-        index === selection.index,
-      0,
-    );
+      index === selection.index
+        ? NO_COLOR
+          ? `${highlightedSeparator.slice(0, -1)}→${truncatedEnd}`
+          : `${highlightedSeparator}${invert(truncatedEnd)}`
+        : `${highlightedSeparator}${truncatedEnd}`;
     return {
       line: `${start}${RESET_COLOR}${cursorHorizontalAbsolute(
         startLength + 1,

--- a/run-pty.js
+++ b/run-pty.js
@@ -1748,8 +1748,7 @@ const runInteractively = (commandDescriptions, autoExit) => {
   /**
    * @returns {void}
    */
-  const killAll = () => {
-    attemptedKillAll = true;
+  const hideSelection = () => {
     selection = {
       tag: "Invisible",
       index:
@@ -1757,6 +1756,14 @@ const runInteractively = (commandDescriptions, autoExit) => {
           ? selection.keyboardIndex
           : selection.index,
     };
+  };
+
+  /**
+   * @returns {void}
+   */
+  const killAll = () => {
+    attemptedKillAll = true;
+    hideSelection();
     for (const command of commands) {
       if (command.status.tag === "Killing") {
         command.status.restartAfterKill = false;
@@ -1779,17 +1786,16 @@ const runInteractively = (commandDescriptions, autoExit) => {
 
   /**
    * @param {string} indicator
-   * @param {number} keyboardIndex
    * @returns {void}
    */
-  const killByIndicator = (indicator, keyboardIndex) => {
+  const killByIndicator = (indicator) => {
     const matchingCommands = commands.filter(
       (command) =>
         getIndicatorChoice(command) === indicator &&
         "terminal" in command.status,
     );
     if (matchingCommands.length === 0) {
-      selection = { tag: "Invisible", index: keyboardIndex };
+      hideSelection();
       // Redraw dashboard.
       switchToDashboard();
     } else {
@@ -1865,10 +1871,9 @@ const runInteractively = (commandDescriptions, autoExit) => {
 
   /**
    * @param {string} indicator
-   * @param {number} keyboardIndex
    * @returns {void}
    */
-  const restartByIndicator = (indicator, keyboardIndex) => {
+  const restartByIndicator = (indicator) => {
     const matchingCommands = commands.filter(
       (command) => getIndicatorChoice(command) === indicator,
     );
@@ -1890,7 +1895,7 @@ const runInteractively = (commandDescriptions, autoExit) => {
     }
 
     attemptedKillAll = false;
-    selection = { tag: "Invisible", index: keyboardIndex };
+    hideSelection();
     // Redraw dashboard.
     switchToDashboard();
   };
@@ -2117,10 +2122,10 @@ const runInteractively = (commandDescriptions, autoExit) => {
  * @param {(index: number, options?: { hideSelection?: boolean }) => void} switchToCommand
  * @param {(newSelection: Selection) => void} setSelection
  * @param {() => void} killAll
- * @param {(indicator: string, keyboardIndex: number) => void} killByIndicator
+ * @param {(indicator: string) => void} killByIndicator
  * @param {(index: number, status: Extract<Status, {tag: "Exit"}>) => void} restart
  * @param {() => void} restartExited
- * @param {(indicator: string, keyboardIndex: number) => void} restartByIndicator
+ * @param {(indicator: string) => void} restartByIndicator
  * @returns {undefined}
  */
 const onStdin = (
@@ -2218,7 +2223,7 @@ const onStdin = (
               return undefined;
             }
             case "ByIndicator":
-              killByIndicator(selection.indicator, selection.keyboardIndex);
+              killByIndicator(selection.indicator);
               return undefined;
           }
 
@@ -2232,7 +2237,7 @@ const onStdin = (
               switchToCommand(selection.index);
               return undefined;
             case "ByIndicator":
-              restartByIndicator(selection.indicator, selection.keyboardIndex);
+              restartByIndicator(selection.indicator);
               return undefined;
           }
 

--- a/run-pty.js
+++ b/run-pty.js
@@ -443,16 +443,6 @@ const drawDashboard = ({
   // https://github.com/microsoft/terminal/issues/376
   const click = IS_WINDOWS ? "" : ` ${dim("(or click)")}`;
 
-  const selectedCommandsForKilling =
-    selection.tag === "ByIndicator"
-      ? commands.filter(
-          (command) => getIndicatorChoice(command) === selection.indicator,
-        )
-      : selection.tag === "Keyboard" &&
-        "terminal" in commands[selection.index].status
-      ? [commands[selection.index]]
-      : [];
-
   const enter =
     selection.tag === "Keyboard"
       ? `${shortcut(KEYS.enter)} focus selected${getPid(
@@ -460,8 +450,10 @@ const drawDashboard = ({
         )}\n${shortcut(KEYS.unselect)} unselect`
       : selection.tag === "ByIndicator"
       ? `${shortcut(KEYS.enter)} ${
-          selectedCommandsForKilling.every(
-            (command) => command.status.tag === "Killing",
+          commands.some(
+            (command) =>
+              getIndicatorChoice(command) === selection.indicator &&
+              command.status.tag === "Killing",
           )
             ? "force "
             : ""

--- a/run-pty.js
+++ b/run-pty.js
@@ -364,9 +364,12 @@ const drawDashboardCommandLines = (
       icon === selectedIndicator
         ? NO_COLOR
           ? `${separator.slice(0, -1)}→${icon}`
-          : // Add two spaces at the end to make sure that two terminal slots get
-            // inverted, no matter the width of the icon.
-            `${separator.slice(0, -1)}${invert(` ${icon}  `)}`
+          : // Add spaces at the end to make sure that two terminal slots get
+            // inverted, no matter the actual width of the icon (which may even
+            // be the empty string).
+            `${separator.slice(0, -1)}${invert(
+              ` ${icon}${" ".repeat(ICON_WIDTH)}`,
+            )}`
         : `${separator}${icon}`;
     const start = truncate(`${label}${finalIcon}`, width);
     const startLength =

--- a/run-pty.js
+++ b/run-pty.js
@@ -139,10 +139,9 @@ const killingIndicator = NO_COLOR
   : "⭕";
 
 const restartingIndicator = NO_COLOR
-  ? // TODO: Fallback icons
-    "○"
+  ? "◌"
   : !SUPPORTS_EMOJI
-  ? `\x1B[91m○${RESET_COLOR}`
+  ? `\x1B[96m◌${RESET_COLOR}`
   : "🔄";
 
 const abortedIndicator = NO_COLOR

--- a/run-pty.js
+++ b/run-pty.js
@@ -377,22 +377,27 @@ const drawDashboardCommandLines = (
   );
 
   const selectedIndicator =
-    selection.tag === "ByIndicator" ? selection.indicator : "";
+    selection.tag === "ByIndicator" ? selection.indicator : undefined;
 
   /**
    * @param {string} string
    * @param {boolean} isSelected
+   * @param {number} pad
    * @returns {string}
    */
-  const highlightWithSeparator = (string, isSelected) =>
+  const highlightWithSeparator = (string, isSelected, pad) =>
     isSelected
       ? NO_COLOR
         ? `${separator.slice(0, -1)}→${string}`
-        : `${separator}${invert(string)}`
+        : `${separator}${invert(string + " ".repeat(pad))}`
       : `${separator}${string}`;
 
   return lines.map(({ label, icon, status, title }, index) => {
-    const finalIcon = highlightWithSeparator(icon, icon === selectedIndicator);
+    const finalIcon = highlightWithSeparator(
+      icon,
+      icon === selectedIndicator,
+      2, // Make sure that two terminal slots get inverted, no matter the width of the icon.
+    );
     const start = truncate(`${label}${finalIcon}`, width);
     const startLength =
       removeGraphicRenditions(label).length + separator.length + ICON_WIDTH;
@@ -409,6 +414,7 @@ const drawDashboardCommandLines = (
       truncatedEnd,
       (selection.tag === "Mousedown" || selection.tag === "Keyboard") &&
         index === selection.index,
+      0,
     );
     return {
       line: `${start}${RESET_COLOR}${cursorHorizontalAbsolute(

--- a/run-pty.js
+++ b/run-pty.js
@@ -1750,6 +1750,13 @@ const runInteractively = (commandDescriptions, autoExit) => {
    */
   const killAll = () => {
     attemptedKillAll = true;
+    selection = {
+      tag: "Invisible",
+      index:
+        selection.tag === "ByIndicator"
+          ? selection.keyboardIndex
+          : selection.index,
+    };
     for (const command of commands) {
       if (command.status.tag === "Killing") {
         command.status.restartAfterKill = false;

--- a/run-pty.js
+++ b/run-pty.js
@@ -1360,6 +1360,7 @@ class Command {
           this.status.terminal.write(this.killAllSequence);
         }
         this.status.lastKillPress = now;
+        this.status.restartAfterKill = restartAfterKill;
         return undefined;
       }
 

--- a/run-pty.js
+++ b/run-pty.js
@@ -138,6 +138,13 @@ const killingIndicator = NO_COLOR
   ? `\x1B[91m○${RESET_COLOR}`
   : "⭕";
 
+const restartingIndicator = NO_COLOR
+  ? // TODO: Fallback icons
+    "○"
+  : !SUPPORTS_EMOJI
+  ? `\x1B[91m○${RESET_COLOR}`
+  : "🔄";
+
 const abortedIndicator = NO_COLOR
   ? "▲"
   : !SUPPORTS_EMOJI
@@ -740,7 +747,10 @@ const statusText = (
       return [statusFromRules, undefined];
 
     case "Killing":
-      return [killingIndicator, undefined];
+      return [
+        status.restartAfterKill ? restartingIndicator : killingIndicator,
+        undefined,
+      ];
 
     case "Exit":
       return [

--- a/run-pty.js
+++ b/run-pty.js
@@ -1874,6 +1874,8 @@ const runInteractively = (commandDescriptions, autoExit) => {
    * @returns {void}
    */
   const restartByIndicator = (indicator) => {
+    attemptedKillAll = false;
+    hideSelection();
     const matchingCommands = commands.filter(
       (command) => getIndicatorChoice(command) === indicator,
     );
@@ -1894,8 +1896,6 @@ const runInteractively = (commandDescriptions, autoExit) => {
       }
     }
 
-    attemptedKillAll = false;
-    hideSelection();
     // Redraw dashboard.
     switchToDashboard();
   };
@@ -2206,8 +2206,6 @@ const onStdin = (
         case KEY_CODES.kill:
           switch (selection.tag) {
             case "Invisible":
-              killAll();
-              return undefined;
             case "Mousedown":
               killAll();
               return undefined;

--- a/test/run-pty.test.js
+++ b/test/run-pty.test.js
@@ -200,8 +200,7 @@ describe("dashboard", () => {
     expect(testDashboard([], { width: 0 })).toMatchInlineSnapshot(`
       ⧙[⧘⧙⧘⧙]⧘       focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ exit
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
     `);
   });
 
@@ -218,8 +217,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ exit
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
       ⧙[⧘⧙enter⧘⧙]⧘  restart exited
     `);
   });
@@ -241,7 +239,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙↑↓⧘⧙]⧘     move selection
 
       At most 3 commands run at a time.
       The session ends automatically once all commands are ⚪ ⧙exit 0⧘.
@@ -265,7 +263,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙↑↓⧘⧙]⧘     move selection
 
       At most 1 command runs at a time.
       The session ends automatically once all commands are ⚪ ⧙exit 0⧘.
@@ -289,7 +287,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙↑↓⧘⧙]⧘     move selection
 
       At most 2 commands run at a time.
       The session ends automatically once all commands are ⚪ ⧙exit 0⧘.
@@ -319,7 +317,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1-2⧘⧙]⧘    focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙↑↓⧘⧙]⧘     move selection
       ⧙[⧘⧙enter⧘⧙]⧘  restart failed
 
       At most 3 commands run at a time.
@@ -349,8 +347,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
     `);
   });
 
@@ -376,8 +373,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
     `);
   });
 
@@ -407,7 +403,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙↑↓⧘⧙]⧘     move selection
 
       At most 3 commands run at a time.
       The session ends automatically once all commands are ⚪ ⧙exit 0⧘.
@@ -512,8 +508,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1-7⧘⧙]⧘    focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
       ⧙[⧘⧙enter⧘⧙]⧘  restart exited
     `);
   });
@@ -595,8 +590,7 @@ describe("dashboard", () => {
 
       ⧙[⧘⧙1-9/a-z/A-Z⧘⧙]⧘ focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
-      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
-      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+      ⧙[⧘⧙↑↓←→⧘⧙]⧘   move selection
     `);
   });
 });

--- a/test/run-pty.test.js
+++ b/test/run-pty.test.js
@@ -201,6 +201,7 @@ describe("dashboard", () => {
       ⧙[⧘⧙⧘⧙]⧘       focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ exit
       ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
     `);
   });
 
@@ -218,6 +219,7 @@ describe("dashboard", () => {
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ exit
       ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
       ⧙[⧘⧙enter⧘⧙]⧘  restart exited
     `);
   });
@@ -336,6 +338,7 @@ describe("dashboard", () => {
               terminal: fakeTerminal({ pid: 1 }),
               slow: false,
               lastKillPress: undefined,
+              restartAfterKill: false,
             },
           },
         ],
@@ -347,6 +350,34 @@ describe("dashboard", () => {
       ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
       ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
+    `);
+  });
+
+  test("attempted to restart", () => {
+    expect(
+      testDashboard(
+        [
+          {
+            command: ["npm", "start"],
+            status: {
+              tag: "Killing",
+              terminal: fakeTerminal({ pid: 1 }),
+              slow: false,
+              lastKillPress: undefined,
+              restartAfterKill: true,
+            },
+          },
+        ],
+        { attemptedKillAll: true },
+      ),
+    ).toMatchInlineSnapshot(`
+      ⧙[⧘⧙1⧘⧙]⧘  🔄⧘  npm start⧘
+
+      ⧙[⧘⧙1⧘⧙]⧘      focus command ⧙(or click)⧘
+      ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
+      ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
     `);
   });
 
@@ -361,6 +392,7 @@ describe("dashboard", () => {
               terminal: fakeTerminal({ pid: 1 }),
               slow: false,
               lastKillPress: undefined,
+              restartAfterKill: false,
             },
           },
         ],
@@ -436,6 +468,18 @@ describe("dashboard", () => {
             terminal: fakeTerminal({ pid: 12345 }),
             slow: false,
             lastKillPress: undefined,
+            restartAfterKill: false,
+          },
+          statusFromRules: "!", // Should be ignored.
+        },
+        {
+          command: ["ping", "localhost"],
+          status: {
+            tag: "Killing",
+            terminal: fakeTerminal({ pid: 12345 }),
+            slow: false,
+            lastKillPress: undefined,
+            restartAfterKill: true,
           },
           statusFromRules: "!", // Should be ignored.
         },
@@ -462,12 +506,14 @@ describe("dashboard", () => {
       ⧙[⧘⧙2⧘⧙]⧘  ⚪⧘  ⧙exit 130⧘  npm run server⧘
       ⧙[⧘⧙3⧘⧙]⧘  🔴⧘  ⧙exit 68⧘   ping nope⧘
       ⧙[⧘⧙4⧘⧙]⧘  ⭕⧘  ping localhost⧘
-      ⧙[⧘⧙5⧘⧙]⧘  🟢⧘  yes⧘
-      ⧙[⧘⧙6⧘⧙]⧘  🚨⧘  very long title for some reason that needs to be cut off at some point⧘
+      ⧙[⧘⧙5⧘⧙]⧘  🔄⧘  ping localhost⧘
+      ⧙[⧘⧙6⧘⧙]⧘  🟢⧘  yes⧘
+      ⧙[⧘⧙7⧘⧙]⧘  🚨⧘  very long title for some reason that needs to be cut off at some point⧘
 
-      ⧙[⧘⧙1-6⧘⧙]⧘    focus command ⧙(or click)⧘
+      ⧙[⧘⧙1-7⧘⧙]⧘    focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all ⧙(double-press to force) ⧘
       ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
       ⧙[⧘⧙enter⧘⧙]⧘  restart exited
     `);
   });
@@ -550,6 +596,7 @@ describe("dashboard", () => {
       ⧙[⧘⧙1-9/a-z/A-Z⧘⧙]⧘ focus command ⧙(or click)⧘
       ⧙[⧘⧙ctrl+c⧘⧙]⧘ kill all
       ⧙[⧘⧙↑/↓⧘⧙]⧘    move selection
+      ⧙[⧘⧙tab⧘⧙]⧘    select by indicator
     `);
   });
 });


### PR DESCRIPTION
This allows you to press <kbd>←</kbd> in the dashboard to select all commands with the same indicator (emoji), and then <kbd>↑</kbd> and <kbd>↓</kbd> to selected the next indicator and all its commands. Once selected, press <kbd>enter</kbd> to restart the selected commands. Press <kbd>→</kbd> to go back.

This is useful if you run watchers as commands. Let’s say you use `nodemon` to run `ts-node server.ts`. If `ts-node server.ts` exits with an error code, `nodemon` is going to keep running and restart `ts-node server.ts` when a .ts file changes. That’s usually what you want: `ts-node` probably exited because a TypeScript error, so the solution is to edit .ts files to fix it. But sometimes it exits when the TypeScript is correct but the application ran into a non-recoverable state (such as a missing environment variable). Then you want to restart the whole `nodemon` process.

In the dashboard, we’ve had the “restart exited” action for a while, but in this case no command has exited. With “select by indicator” you can select all commands that have the 🟢 (running) indicator and restart those. Even better, if you use run-pty with a .json file you might have customized the indicator to be, say, 🚨 when a watcher is in an error state. Then you can select all commands with the 🚨 indicator and restart those.