### PR TITLE
Add workaround for io_uring bug on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ If you want a shell, you could do something like this: `run-pty % bash -c 'npm i
 
 ## Credits
 
-- [microsoft/node-pty] does all the heavy lifting of running the commands.
+- [microsoft/node-pty] does all the heavy lifting of running the commands. But it’s actually the fork [@lydell/node-pty] that is used. The only difference is that it has prebuilt binaries.
 - [apiel/run-screen] was the inspiration for this tool.
 
 ## iTerm2 flicker
@@ -230,6 +230,7 @@ run-pty tries to avoid clearing the screen and only redraw lines that have chang
 
 [MIT](LICENSE).
 
+[@lydell/node-pty]: https://github.com/lydell/node-pty
 [apiel/run-screen]: https://github.com/apiel/run-screen
 [concurrently]: https://github.com/kimmobrunfeldt/concurrently
 [gnu parallel]: https://www.gnu.org/software/parallel/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "run-pty",
-  "version": "4.1.0",
+  "version": "5.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "run-pty",
-      "version": "4.1.0",
+      "version": "5.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "node-pty": "^1.0.0",
+        "@lydell/node-pty": "^1.0.0-beta.2",
         "tiny-decoders": "^23.0.0"
       },
       "bin": {
@@ -492,6 +492,68 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.0.0-beta.2.tgz",
+      "integrity": "sha512-i0YmbD/ufnUTp7LNyrVVVMll+gNaFymEV5Y4rcUXP2sXSODRbCcRaoP5lcEfb0xrFwEfBb+/MhzL22fQRagZ7g==",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      },
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.0.0-beta.2",
+        "@lydell/node-pty-darwin-x64": "1.0.0-beta.2",
+        "@lydell/node-pty-linux-x64": "1.0.0-beta.2",
+        "@lydell/node-pty-win32-x64": "1.0.0-beta.2"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.0.0-beta.2.tgz",
+      "integrity": "sha512-QhfJvZ2QamWWHb37Yi/npTO/uvD703lWGv9UD/RQ1BoyAMejoqVKj5ty2gbF3JgcGRiUwZpgGvm/zYywWxPIPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.0.0-beta.2.tgz",
+      "integrity": "sha512-LunTRVJEjU5ksj1PvS60Fn1qaaBSZfp6ot48KPA5tfAw7nwVj/tIdWqlZbGyM7e40OmpoD8fEDpZg3gLlap9Tw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.0.0-beta.2.tgz",
+      "integrity": "sha512-XxPHBMP+bNbpR/JUIxxX5nmfsEeleJ6txRCrEfltJtTVJAGoMs4giqaba3pApTcIOloUi4tI909hBU8ztH3+bg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.0.0-beta.2.tgz",
+      "integrity": "sha512-RY+YlQr1E+XBBaBskp4yVblRWnT1+ujXesAPvt85Msz25XrI3pr5FQbubIm72NTSBbcIvmMKN+DVXxGERNHibA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1836,11 +1898,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -1865,13 +1922,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-pty": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
-      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "nan": "^2.17.0"
+    "node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/once": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Run several commands concurrently. Show output for one command at a time. Kill all at once.",
   "repository": "lydell/run-pty",
   "type": "commonjs",
-  "bin": "./run-pty.js",
+  "bin": "./run-pty-bin.js",
   "files": [
     "run-pty.js"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-pty",
-  "version": "4.1.0",
+  "version": "5.0.0-beta.1",
   "author": "Simon Lydell",
   "license": "MIT",
   "description": "Run several commands concurrently. Show output for one command at a time. Kill all at once.",
@@ -24,7 +24,7 @@
     "xterm"
   ],
   "dependencies": {
-    "node-pty": "^1.0.0",
+    "@lydell/node-pty": "^1.0.0-beta.2",
     "tiny-decoders": "^23.0.0"
   },
   "devDependencies": {

--- a/run-pty-bin.js
+++ b/run-pty-bin.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+"use strict";
+
+// Workaround for:
+// https://github.com/lydell/run-pty/issues/45
+// https://github.com/lydell/run-pty/issues/53
+if (process.platform === "linux" && !("UV_USE_IO_URING" in process.env)) {
+  require("child_process")
+    .spawn(
+      process.execPath,
+      [`${__dirname}/run-pty.js`, ...process.argv.slice(2)],
+      {
+        stdio: "inherit",
+        env: { ...process.env, UV_USE_IO_URING: "0" },
+      },
+    )
+    .on("exit", process.exit);
+} else {
+  require("./run-pty.js").__internalRun();
+}

--- a/run-pty.js
+++ b/run-pty.js
@@ -2,6 +2,21 @@
 
 "use strict";
 
+// Workaround for:
+// https://github.com/lydell/run-pty/issues/45
+// https://github.com/lydell/run-pty/issues/53
+if (process.platform === "linux" && !("UV_USE_IO_URING" in process.env)) {
+  require("child_process")
+    .spawn(process.execPath, [__filename, ...process.argv.slice(2)], {
+      stdio: "inherit",
+      env: { UV_USE_IO_URING: "0", ...process.env },
+    })
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    .on("exit", process.exit);
+  // @ts-expect-error This is a deliberate exit.
+  return;
+}
+
 const fs = require("fs");
 const path = require("path");
 const os = require("os");

--- a/run-pty.js
+++ b/run-pty.js
@@ -2,21 +2,6 @@
 
 "use strict";
 
-// Workaround for:
-// https://github.com/lydell/run-pty/issues/45
-// https://github.com/lydell/run-pty/issues/53
-if (process.platform === "linux" && !("UV_USE_IO_URING" in process.env)) {
-  require("child_process")
-    .spawn(process.execPath, [__filename, ...process.argv.slice(2)], {
-      stdio: "inherit",
-      env: { UV_USE_IO_URING: "0", ...process.env },
-    })
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    .on("exit", process.exit);
-  // @ts-expect-error This is a deliberate exit.
-  return;
-}
-
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -2584,6 +2569,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  __internalRun: run,
   __forTests: {
     ALL_LABELS,
     commandToPresentationName,

--- a/run-pty.js
+++ b/run-pty.js
@@ -20,14 +20,14 @@ if (process.platform === "linux" && !("UV_USE_IO_URING" in process.env)) {
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const pty = require("node-pty");
+const pty = require("@lydell/node-pty");
 const Codec = require("tiny-decoders");
 
 /**
  * @typedef {
     | { tag: "Waiting" }
-    | { tag: "Running", terminal: import("node-pty").IPty }
-    | { tag: "Killing", terminal: import("node-pty").IPty, slow: boolean, lastKillPress: number | undefined, restartAfterKill: boolean }
+    | { tag: "Running", terminal: import("@lydell/node-pty").IPty }
+    | { tag: "Killing", terminal: import("@lydell/node-pty").IPty, slow: boolean, lastKillPress: number | undefined, restartAfterKill: boolean }
     | { tag: "Exit", exitCode: number, wasKilled: boolean }
    } Status
  *

--- a/test/run-pty.test.js
+++ b/test/run-pty.test.js
@@ -27,7 +27,7 @@ const {
 
 /**
  * @param {{ pid: number }} init
- * @returns {import("node-pty").IPty}
+ * @returns {import("@lydell/node-pty").IPty}
  */
 function fakeTerminal({ pid }) {
   return {


### PR DESCRIPTION
Workaround for #45 and #53.

Tested here: https://github.com/lydell/run-pty/actions/runs/7942733450/job/21686322753?pr=46.

Released in 4.1.1-beta.1, 5.0.0-beta.1 and 5.0.0-beta.2.

Note that Node.js might remove the `UV_USE_IO_URING` env var at some point according to a Node.js maintainer: https://github.com/nodejs/node/issues/48444#issuecomment-1591882694